### PR TITLE
FROM ryaneggz/8-make-chat-default-behavior TO master

### DIFF
--- a/source/views/HelpView.tsx
+++ b/source/views/HelpView.tsx
@@ -6,10 +6,19 @@ export default function HelpView() {
 			<Text color="yellow" bold>
 				Help - Available Commands:
 			</Text>
+			<Text color="cyan" bold>
+				Default Behavior:
+			</Text>
+			<Text> Type any message (without /) to chat with the AI agent</Text>
+			<Box marginTop={1}>
+				<Text color="yellow" bold>
+					Available Commands:
+				</Text>
+			</Box>
 			<Text color="green">/help</Text>
 			<Text> Show this help message</Text>
 			<Text color="green">/chat</Text>
-			<Text> Start conversing with the AI agent</Text>
+			<Text> Explicitly start conversing with the AI agent</Text>
 			<Text color="green">/models</Text>
 			<Text> List available AI models</Text>
 			<Text color="green">/init</Text>


### PR DESCRIPTION
Closes #8

## Summary
- Makes chat the default behavior when users type input without a slash command
- Removes the need for users to type "/chat" to start chat sessions  
- Any input not starting with "/" automatically initializes and starts a chat session
- All existing slash commands continue to work exactly as before

## Implementation Details
- Refactored command handling logic to separate chat functionality into dedicated functions
- Added `handleChatInput` function that automatically initializes the agent if needed
- Added `processChatMessage` function to handle the actual chat processing logic
- Updated help view to clearly indicate the new default behavior
- Maintained all existing functionality while improving user experience

## Test Plan
- [x] Verify all existing slash commands still work (/help, /models, /init, etc.)
- [x] Confirm non-slash input automatically starts chat mode
- [x] Test agent initialization on first chat message
- [x] Verify error handling for failed agent initialization
- [x] Check that help text accurately reflects new behavior
- [x] Ensure application builds and starts correctly

🤖 Generated with [Claude Code](https://claude.ai/code)