### PR TITLE
feat: add version and health commands

### DIFF
--- a/source/__tests__/health.test.ts
+++ b/source/__tests__/health.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for health command and fetchHealth API function
+ */
+
+import test from 'ava';
+import {fetchHealth} from '../lib/api.js';
+
+// Test fetchHealth with invalid host (network error)
+test('fetchHealth returns error for invalid host', async t => {
+	const result = await fetchHealth('http://localhost:99999');
+
+	t.false(result.success);
+	t.truthy(result.error);
+});
+
+// Test fetchHealth returns correct structure on error
+test('fetchHealth error response has correct structure', async t => {
+	const result = await fetchHealth(
+		'http://invalid-host-that-does-not-exist.local',
+	);
+
+	t.false(result.success);
+	t.is(result.data, undefined);
+	t.truthy(result.error);
+	t.is(typeof result.error, 'string');
+});
+
+// Test fetchHealth handles trailing slash in host
+test('fetchHealth handles trailing slash in host URL', async t => {
+	// This test verifies the URL construction doesn't double-slash
+	// We can't test the actual API call without a server, but we can verify
+	// the function doesn't throw with a trailing slash host
+	const result = await fetchHealth('http://localhost:99999/');
+
+	t.false(result.success);
+	t.truthy(result.error);
+});
+
+// Test that HealthResponse type structure is expected
+test('fetchHealth response includes expected error properties', async t => {
+	const result = await fetchHealth('http://localhost:99999');
+
+	t.true('success' in result);
+	t.true('error' in result || 'data' in result);
+});

--- a/source/__tests__/version.test.ts
+++ b/source/__tests__/version.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for version command
+ */
+
+import test from 'ava';
+import {fetchHealth} from '../lib/api.js';
+
+// The CLI version is hardcoded in the version command
+const cliVersion = '0.1.3';
+
+// Test that CLI version constant is a valid semver-like string
+test('CLI version is a valid version string', t => {
+	t.regex(cliVersion, /^\d+\.\d+\.\d+$/);
+});
+
+// Test fetchHealth (used by version command) returns error structure on failure
+test('version command fetchHealth returns proper error on network failure', async t => {
+	const result = await fetchHealth('http://localhost:99999');
+
+	t.false(result.success);
+	t.truthy(result.error);
+	t.is(result.data, undefined);
+});
+
+// Test fetchHealth response type structure
+test('version command fetchHealth response has expected shape', async t => {
+	const result = await fetchHealth('http://invalid-host.local');
+
+	// Verify response structure
+	t.true('success' in result);
+	t.is(typeof result.success, 'boolean');
+
+	// On error, data should be undefined and error should be a string
+	if (!result.success) {
+		t.is(result.data, undefined);
+		t.is(typeof result.error, 'string');
+	}
+});
+
+// Test that version command would show CLI version even on API failure
+test('CLI version is accessible for display regardless of API status', t => {
+	// The version command displays CLI version even when API is unavailable
+	// This test verifies the constant is available
+	t.truthy(cliVersion);
+	t.is(typeof cliVersion, 'string');
+	t.true(cliVersion.length > 0);
+});

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -10,6 +10,8 @@ import {runAssistantCommand} from './commands/assistant.js';
 import {runModelsCommand} from './commands/models.js';
 import {runCreateAssistantCommand} from './commands/create-assistant.js';
 import {runChatCommand} from './commands/chat.js';
+import {runVersionCommand} from './commands/version.js';
+import {runHealthCommand} from './commands/health.js';
 
 const cli = meow(
 	`
@@ -23,6 +25,8 @@ const cli = meow(
 	  chat <message>    Chat with an assistant or continue a thread
 	  create            Create a new assistant
 	  models            List available models
+	  version           Show CLI and API version
+	  health            Check API health status
 
 	Options
 	  --ui              Launch interactive TUI mode
@@ -191,6 +195,16 @@ async function main() {
 				systemPrompt: cli.flags.systemPrompt,
 				tools: cli.flags.tools,
 			});
+			break;
+		}
+
+		case 'version': {
+			await runVersionCommand();
+			break;
+		}
+
+		case 'health': {
+			await runHealthCommand();
 			break;
 		}
 

--- a/source/commands/health.tsx
+++ b/source/commands/health.tsx
@@ -1,0 +1,111 @@
+import React, {useState, useEffect} from 'react';
+import {render, Text, Box, useApp} from 'ink';
+import Spinner from 'ink-spinner';
+import {type HealthResponse, hostPresets} from '../types/index.js';
+import {loadConfig} from '../lib/config.js';
+import {fetchHealth} from '../lib/api.js';
+
+type Status = 'loading' | 'success' | 'error';
+
+function HealthCommand() {
+	const {exit} = useApp();
+	const [status, setStatus] = useState<Status>('loading');
+	const [health, setHealth] = useState<HealthResponse | undefined>(undefined);
+	const [error, setError] = useState<string | undefined>(undefined);
+	const [host, setHost] = useState<string>('');
+
+	useEffect(() => {
+		const checkHealth = async () => {
+			// Try to load config for host, fall back to production
+			const config = await loadConfig();
+			const targetHost = config?.host ?? hostPresets.production;
+			setHost(targetHost);
+
+			// Fetch health status
+			const result = await fetchHealth(targetHost);
+
+			if (result.success && result.data) {
+				setHealth(result.data);
+				setStatus('success');
+			} else {
+				setError(result.error ?? 'Failed to fetch health status');
+				setStatus('error');
+			}
+
+			setTimeout(() => {
+				exit();
+			}, 100);
+		};
+
+		void checkHealth();
+	}, [exit]);
+
+	if (status === 'loading') {
+		return (
+			<Box>
+				<Text color="cyan">
+					<Spinner type="dots" />
+				</Text>
+				<Text> Checking health...</Text>
+			</Box>
+		);
+	}
+
+	if (status === 'error') {
+		return (
+			<Box flexDirection="column">
+				<Box marginBottom={1}>
+					<Text bold color="cyan">
+						Health Check
+					</Text>
+					<Text dimColor> ({host})</Text>
+				</Box>
+
+				<Text>
+					<Text dimColor>Status: </Text>
+					<Text bold color="red">
+						unhealthy
+					</Text>
+				</Text>
+				<Text>
+					<Text dimColor>Error: </Text>
+					<Text color="red">{error}</Text>
+				</Text>
+			</Box>
+		);
+	}
+
+	// Success - display health info
+	const statusColor = health?.status === 'healthy' ? 'green' : 'yellow';
+
+	return (
+		<Box flexDirection="column">
+			<Box marginBottom={1}>
+				<Text bold color="cyan">
+					Health Check
+				</Text>
+				<Text dimColor> ({host})</Text>
+			</Box>
+
+			<Text>
+				<Text dimColor>Status: </Text>
+				<Text bold color={statusColor}>
+					{health?.status}
+				</Text>
+			</Text>
+			<Text>
+				<Text dimColor>Message: </Text>
+				<Text>{health?.message}</Text>
+			</Text>
+			<Text>
+				<Text dimColor>Version: </Text>
+				<Text>{health?.version}</Text>
+			</Text>
+		</Box>
+	);
+}
+
+export async function runHealthCommand(): Promise<void> {
+	const {waitUntilExit} = render(<HealthCommand />);
+	await waitUntilExit();
+}

--- a/source/commands/version.tsx
+++ b/source/commands/version.tsx
@@ -1,0 +1,86 @@
+import React, {useState, useEffect} from 'react';
+import {render, Text, Box, useApp} from 'ink';
+import Spinner from 'ink-spinner';
+import {type HealthResponse, hostPresets} from '../types/index.js';
+import {loadConfig} from '../lib/config.js';
+import {fetchHealth} from '../lib/api.js';
+
+type Status = 'loading' | 'success' | 'error';
+
+const cliVersion = '0.1.3';
+
+function VersionCommand() {
+	const {exit} = useApp();
+	const [status, setStatus] = useState<Status>('loading');
+	const [health, setHealth] = useState<HealthResponse | undefined>(undefined);
+	const [error, setError] = useState<string | undefined>(undefined);
+	const [host, setHost] = useState<string>('');
+
+	useEffect(() => {
+		const getVersion = async () => {
+			// Try to load config for host, fall back to production
+			const config = await loadConfig();
+			const targetHost = config?.host ?? hostPresets.production;
+			setHost(targetHost);
+
+			// Fetch health to get API version
+			const result = await fetchHealth(targetHost);
+
+			if (result.success && result.data) {
+				setHealth(result.data);
+				setStatus('success');
+			} else {
+				setError(result.error ?? 'Failed to fetch API version');
+				setStatus('error');
+			}
+
+			setTimeout(() => {
+				exit();
+			}, 100);
+		};
+
+		void getVersion();
+	}, [exit]);
+
+	if (status === 'loading') {
+		return (
+			<Box>
+				<Text color="cyan">
+					<Spinner type="dots" />
+				</Text>
+				<Text> Loading version info...</Text>
+			</Box>
+		);
+	}
+
+	// Always show CLI version
+	return (
+		<Box flexDirection="column">
+			<Text>
+				<Text bold color="cyan">
+					@ruska/cli
+				</Text>
+				<Text> v{cliVersion}</Text>
+			</Text>
+
+			{status === 'error' ? (
+				<Text>
+					<Text bold>API:</Text>
+					<Text color="red"> unavailable</Text>
+					<Text dimColor> ({error})</Text>
+				</Text>
+			) : (
+				<Text>
+					<Text bold>API:</Text>
+					<Text color="green"> v{health?.version}</Text>
+					<Text dimColor> ({host})</Text>
+				</Text>
+			)}
+		</Box>
+	);
+}
+
+export async function runVersionCommand(): Promise<void> {
+	const {waitUntilExit} = render(<VersionCommand />);
+	await waitUntilExit();
+}

--- a/source/lib/api.ts
+++ b/source/lib/api.ts
@@ -4,6 +4,7 @@ import {
 	type UserInfo,
 	type AssistantsSearchResponse,
 	type ModelsResponse,
+	type HealthResponse,
 	type CreateAssistantRequest,
 	type CreateAssistantResponse,
 } from '../types/index.js';
@@ -167,6 +168,50 @@ export async function fetchModels(
 		}
 
 		const data = (await response.json()) as ModelsResponse;
+		return {
+			success: true,
+			data,
+		};
+	} catch (error: unknown) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : 'Unknown error occurred',
+		};
+	}
+}
+
+/**
+ * Fetch health status (no auth required)
+ */
+export async function fetchHealth(
+	host: string,
+): Promise<ApiResponse<HealthResponse>> {
+	const url = `${host.replace(/\/$/, '')}/api/info/health`;
+
+	try {
+		const response = await fetch(url, {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			let errorMessage: string;
+			try {
+				const errorJson = JSON.parse(errorText) as {detail?: string};
+				errorMessage = errorJson.detail ?? `HTTP ${response.status}`;
+			} catch {
+				errorMessage = errorText || `HTTP ${response.status}`;
+			}
+
+			return {
+				success: false,
+				error: errorMessage,
+			};
+		}
+
+		const data = (await response.json()) as HealthResponse;
 		return {
 			success: true,
 			data,

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -88,6 +88,15 @@ export type ModelsResponse = {
 };
 
 /**
+ * Response from GET /api/health
+ */
+export type HealthResponse = {
+	status: string;
+	message: string;
+	version: string;
+};
+
+/**
  * Host presets for environment selection
  */
 export const hostPresets = {


### PR DESCRIPTION
## Summary

Add two new CLI commands for getting version info and health status:

- **`ruska version`** - Display CLI version and API version info
- **`ruska health`** - Check API health status

### Features

**Version Command:**
- Shows CLI version (`@ruska/cli v0.1.3`)
- Fetches and displays API version from `/api/info/health` endpoint
- Gracefully handles API unavailability

**Health Command:**
- Checks API health status
- Displays status, message, and version
- Color-coded output (green for healthy, red for errors)

### Changes

- Add `HealthResponse` type to `types/index.ts`
- Add `fetchHealth()` function to `lib/api.ts`
- Create `version.tsx` command component
- Create `health.tsx` command component
- Update CLI router with new command routes
- Add unit tests for both commands

### Example Output

```
$ ruska version
@ruska/cli v0.1.3
API: v0.1.0 (http://localhost:8000)

$ ruska health
Health Check (http://localhost:8000)

Status: healthy
Message: Service is running
Version: 0.1.0
```

## Test plan

- [x] All 54 unit tests pass (`npm test`)
- [x] Linting passes with no new errors
- [x] Manual testing with production API
- [x] Manual testing with local development server
- [x] Manual testing with unreachable server (error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)